### PR TITLE
Second Startup Window

### DIFF
--- a/_posts/2014-09-27-starting-a-session.md
+++ b/_posts/2014-09-27-starting-a-session.md
@@ -52,6 +52,8 @@ to open a Session created at the current JACK Sample Rate. For example,
 a Session created when JACK was running at 96 kHz will not open if JACK
 is currently running at 48 kHz.
 
+---Second Startup Window?---
+
 To create an Ardour session after Ardour has already started, select
 **Session** > **New** in the menu.
 


### PR DESCRIPTION
For those not using Jack there is now a second startup window when creating a new session.  Do we want a screenshot and explanation for this?
