### PR TITLE
Fix incorrect link on Dummy Page

### DIFF
--- a/_posts/2014-04-10-dummy-page.md
+++ b/_posts/2014-04-10-dummy-page.md
@@ -14,7 +14,7 @@ image:
 
 This page is for GitHub first-timers who want to contribute to the Ardour tutorial, but would like to get a little practice first.
 
-Feel free to use this page as a testing ground. Try submitting an issue about this page, or editing it in place through your browser. Click [here](../how-to-contribute) for detailed information on how to do it. For example, fix any one of the misspelled words below.
+Feel free to use this page as a testing ground. Try submitting an issue about this page, or editing it in place through your browser. Click [here](../how-to-contribute-0) for detailed information on how to do it. For example, fix any one of the misspelled words below.
 
 1. acommodate
 


### PR DESCRIPTION
Proposed change corrects link on line 17 so that it goes to "How To Contribute" page.
